### PR TITLE
docs: fix "Custom EntryPoint" snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Because Serde.FS uses source generation, it cannot safely generate the real entr
 To solve this, mark your intended entry point with:  
  
 ```fsharp
-[<FSharp.SourceDjinn.EntryPoint>]
+[<FSharp.SourceDjinn.TypeModel.EntryPoint>]
 let main argv = ...
 ```  
  


### PR DESCRIPTION
While trying this project, I discovered that the EntryPoint snippet is incorrect.

Or at least, I was not able to find the `FSharp.SourceDjinn.EntryPoint` but instead it seems to be in `FSharp.SourceDjinn.TypeModel.EntryPoint`