### PR TITLE
chore: track an "empty" `.nuget-local` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,8 @@ nunit-*.xml
 .vs/
 /src/Serde.FS.Json/analyzers/dotnet/fs/*.dll
 /src/FSharp.SourceDjinn/analyzers/dotnet/fs/*.dll
-.nuget-local/
+.nuget-local/*
+!.nuget-local/.keep
 src/Serde.FS.Json.SampleApp/Directory.Build.props
 .debug-counter
 .build/


### PR DESCRIPTION
If the user don't have `.nuget-local` folder, then he will get this error when trying to Load, Build or Restore the solution.

> /home/mmangel/Workspaces/Github/fs-djinn/Serde.FS/main/src/Serde.FS.SourceGen/Serde.FS.SourceGen.fsproj : error NU1301: The local source '/home/mmangel/Workspaces/Github/fs-djinn/Serde.FS/main/.nuget-local' doesn't exist.